### PR TITLE
feat(deploy): CNAME mods for deploy

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -79,3 +79,61 @@ spec:
         backend:
           serviceName: cs4300piazza
           servicePort: 443
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: cs4300piazza-mci
+  namespace: ingress-basic
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.allow-http: "false"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    certmanager.k8s.io/acme-challenge-type: dns01
+    certmanager.k8s.io/acme-dns01-provider: route53
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+  - hosts:
+    - mci.cis.cornell.edu
+    secretName: tls-secret2
+  rules:
+  - host: mci.cis.cornell.edu
+    http:
+      paths:
+      - path: /?(.*)
+        backend:
+          serviceName: cs4300piazza
+          servicePort: 443
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: cs4300piazza-mci2
+  namespace: ingress-basic
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.allow-http: "false"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    certmanager.k8s.io/acme-challenge-type: dns01
+    certmanager.k8s.io/acme-dns01-provider: route53
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: 200m
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+  - hosts:
+    - mycourseindex.cis.cornell.edu
+    secretName: tls-secret3
+  rules:
+  - host: mycourseindex.cis.cornell.edu
+    http:
+      paths:
+      - path: /?(.*)
+        backend:
+          serviceName: cs4300piazza
+          servicePort: 443


### PR DESCRIPTION
# Objective: Adding cornell.edu based domain names

## Why
We did this to be able to account for the new cnames that COECIS IT will be adding for us. This adds a nice level of professionalism 

## What changed
- Added 2 more ingresses
- Creating two more TLS secrets with CA
- Routing all to current backend

## Tests done
None....not great but this should not damage the current deployment in any way.

## Issues
TBD

closes #133 